### PR TITLE
Create rotriever.toml

### DIFF
--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Reselim/roact-flipper"
+author = "Reselim"
+content_root = "src"
+version = "1.1.0"
+license = "MIT"


### PR DESCRIPTION
Since Wally isn't out of a public beta yet, it might be worth adding a `rotriever.toml` file in so that legacy tools like kayak still can be used. 

I for one am not ready to use Wally since many packages haven't been moved over (and it has no public auth yet!)