### PR TITLE
Destroy motor when component unmounts

### DIFF
--- a/src/useMotor.lua
+++ b/src/useMotor.lua
@@ -12,7 +12,13 @@ local function createMotor(initialValue)
 end
 
 local function useMotor(hooks, initialValue)
-	return hooks.useValue(createMotor(initialValue)).value
+	local motor = hooks.useValue(createMotor(initialValue)).value
+	hooks.useEffect(function ()
+		return function ()
+			motor:destroy()
+		end
+	end, {})
+	return motor
 end
 
 return useMotor


### PR DESCRIPTION
Although motors by default run motor:stop() ([source code](https://github.com/Reselim/Flipper/blob/41380da19278a14ed2c5a34db4f958d090b1994a/src/SingleMotor.lua#L59)), it would be good to do the same when the component unmounts. This PR addresses that.